### PR TITLE
add .mts to DEFAULT_VIDEO_EXTENSIONS

### DIFF
--- a/src/pyvideothumbnailer/videothumbnailer.py
+++ b/src/pyvideothumbnailer/videothumbnailer.py
@@ -314,7 +314,8 @@ class VideoThumbnailer:
                                 '.mov',
                                 '.mp4',
                                 '.mpg',
-                                '.wmv')
+                                '.wmv',
+                                '.mts')
 
     def __init__(self):
         """

--- a/src/pyvideothumbnailer/videothumbnailer.py
+++ b/src/pyvideothumbnailer/videothumbnailer.py
@@ -375,7 +375,7 @@ class VideoThumbnailer:
         parser.add_argument('--rows',
                              type=int,
                              help='The number of preview thumbnail rows.')
-        parser.add_argument('---vertical-video-columns',
+        parser.add_argument('--vertical-video-columns',
                              type=int,
                              help='The number of preview thumbnail columns in place of \'--columns\' in case of vertical videos.')
         parser.add_argument('--vertical-video-rows',


### PR DESCRIPTION
My Sony camera once created .mts Video files (MPEG Transport Stream) and the thumbnailer (PyAV, ffmpeg) handles them just right.

I presume this can be added to the list of supported video file extensions.

Thanks for that great tool!